### PR TITLE
adding test for docker arg

### DIFF
--- a/docker/gap8/Dockerfile
+++ b/docker/gap8/Dockerfile
@@ -38,7 +38,7 @@ RUN pip3 install h5py==2.10.0
 RUN /bin/bash -c "cd gap_sdk/; source configs/ai_deck.sh; ls; make nntool"
 
 
-RUN apt-get install -y libopencv-dev python3-opencv
+RUN apt-get update && apt-get install -y libopencv-dev python3-opencv
 
 RUN /bin/bash -c "cd gap_sdk/; source configs/ai_deck.sh; ls; make gap_tools"
 

--- a/docker/gap8/Dockerfile
+++ b/docker/gap8/Dockerfile
@@ -4,6 +4,7 @@ FROM ubuntu:18.04
 ENV DEBIAN_FRONTEND noninteractive 
 ARG GAP_SDK_VERSION
 RUN echo $GAP_SDK_VERSION
+RUN test -n "$GAP_SDK_VERSION"
 
 # Install needed packages
 RUN apt-get update && apt-get install -y build-essential git libftdi-dev libftdi1 doxygen python3-pip libsdl2-dev curl cmake libusb-1.0-0-dev scons gtkwave libsndfile1-dev rsync autoconf automake texinfo libtool pkg-config libsdl2-ttf-dev 

--- a/docs/getting-started/docker-gap8.md
+++ b/docs/getting-started/docker-gap8.md
@@ -20,7 +20,7 @@ echo 'export GAP_SDK_VERSION=3.8.1' >> ~/.bashrc
 _Note: if you would like to also build docker images for SDK version 3.4, 3.5, 3.6 or 3.7, just replace the previous version number. The build process will checkout the right version of the SDK_
 
 ```
-docker build --tag gapsdk:${GAP_SDK_VERSION} --build-arg GAP_SDK_VERSION .
+docker build --tag gapsdk:${GAP_SDK_VERSION} --build-arg GAP_SDK_VERSION=$GAP_SDK_VERSION .
 ```
 
 Open up the container to install the auto tiler


### PR DESCRIPTION
When attempting to run the [Docker Gap8 instructions](https://www.bitcraze.io/documentation/repository/AIdeck_examples/master/getting-started/docker-gap8/), the [gap_sdk clone instruction](https://github.com/bitcraze/AIdeck_examples/blob/f1a79f1c253123da464e08879a386df91ade8847/docker/gap8/Dockerfile#L19) was causing error:

```
error: pathspec 'tags/release-v' did not match any file(s) known to git.
```
It turned out that my environment variable `GAP_SDK_VERSION` wasn't being properly passed via the `--build-args` command. In theory,  [passing an empty value arg should work](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg), but I never did figure out what was going wrong. 

Unfortunately, the error takes a long time to manifest itself since there are many instructions to run before `GAP_SDK_VERSION` is used. Therefore I added a test to the `Dockerfile` that immediately raises this error so you don't have to wait so long to find it.

By making the `build` command more explicit with `--build-arg GAP_SDK_VERSION=$GAP_SDK_VERSION`, it seemed to work fine.