### PR TITLE
Add support for software access point mode

### DIFF
--- a/GAP8/test_functionalities/wifi_jpeg_streamer/README.md
+++ b/GAP8/test_functionalities/wifi_jpeg_streamer/README.md
@@ -29,6 +29,7 @@ Edit this file to contain the setup for your local WiFi (note that this file is 
 ```c
 static const char ssid[] = "YourSSID";
 static const char passwd[] = "YourWiFiKey";
+static const bool use_soft_ap = false;
 ```
 
 Build and flash the application. **Note:** Due to a bug in the Makefiles in the SDK you will need to use

--- a/GAP8/test_functionalities/wifi_jpeg_streamer/wifi.h
+++ b/GAP8/test_functionalities/wifi_jpeg_streamer/wifi.h
@@ -3,13 +3,13 @@
 #include <stdint.h>
 
 typedef enum {
-  SET_SSID = 0x10,
-  SET_KEY = 0x11,
+  WIFI_CTRL_SET_SSID                = 0x10,
+  WIFI_CTRL_SET_KEY                 = 0x11,
 
-  WIFI_CONNECT = 0x20,
-  
-  STATUS_WIFI_CONNECTED = 0x31,
-  STATUS_CLIENT_CONNECTED = 0x32
+  WIFI_CTRL_WIFI_CONNECT            = 0x20,
+
+  WIFI_CTRL_STATUS_WIFI_CONNECTED   = 0x31,
+  WIFI_CTRL_STATUS_CLIENT_CONNECTED = 0x32,
 } __attribute__((packed)) WiFiCTRLType;
 
 typedef struct {


### PR DESCRIPTION
This changes the definition of WIFI_CTRL_WIFI_CONNECT (now with an
additional payload) and thus requires an updated NINA firmware as well.